### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,22 +10,22 @@
 # Methods and Functions (KEYWORD1)
 #######################################
 
-begin         KEYWORD1
-pinMode	      KEYWORD1
-digitalRead	  KEYWORD1
-digitalWrite  KEYWORD1
-pinMode	      KEYWORD1
-wordWrite	  KEYWORD1
-byteWrite	  KEYWORD1
-byteRead	  KEYWORD1
-pullupMode	  KEYWORD1
-inputInvert	  KEYWORD1
+begin	KEYWORD1
+pinMode	KEYWORD1
+digitalRead	KEYWORD1
+digitalWrite	KEYWORD1
+pinMode	KEYWORD1
+wordWrite	KEYWORD1
+byteWrite	KEYWORD1
+byteRead	KEYWORD1
+pullupMode	KEYWORD1
+inputInvert	KEYWORD1
 
 #######################################
 # Instances (KEYWORD2)
 #######################################
 
-MCP	        KEYWORD2
+MCP	KEYWORD2
 MCP23S17	KEYWORD2
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords